### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,8 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
 jobs:
   lint-and-typecheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/leonardocustodio/mkdocs-copy-to-llm/security/code-scanning/1](https://github.com/leonardocustodio/mkdocs-copy-to-llm/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow. Since the workflow only checks out code and runs linting/type checking, it does not need write access to repository contents or other resources. The minimal required permission is `contents: read`. You can add this block at the root level of the workflow file (above `jobs:`) to apply it to all jobs, or at the job level if you want to be more granular. The best practice is to add it at the root level unless specific jobs require different permissions.

Edit `.github/workflows/lint.yml` and insert the following block after the workflow `name` and before `on:` or after `on:` and before `jobs:`:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
