### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete URL substring sanitization

### DIFF
--- a/mkdocs_copy_to_llm/assets/js/copy-to-llm.js
+++ b/mkdocs_copy_to_llm/assets/js/copy-to-llm.js
@@ -108,11 +108,16 @@ ${content}`;
       // GitHub edit URL: https://github.com/owner/repo/edit/branch/path/to/file.md
       // Raw URL: https://raw.githubusercontent.com/owner/repo/branch/path/to/file.md
       const editUrl = editLink.href;
-      if (editUrl.includes('github.com')) {
-        return editUrl
-          .replace('github.com', 'raw.githubusercontent.com')
-          .replace('/edit/', '/')
-          .replace('/blob/', '/');
+      try {
+        const parsedUrl = new URL(editUrl);
+        if (parsedUrl.hostname === 'github.com') {
+          return editUrl
+            .replace('github.com', 'raw.githubusercontent.com')
+            .replace('/edit/', '/')
+            .replace('/blob/', '/');
+        }
+      } catch (e) {
+        // If URL parsing fails, fall through to fallback logic
       }
     }
 


### PR DESCRIPTION
### **User description**
Potential fix for [https://github.com/leonardocustodio/mkdocs-copy-to-llm/security/code-scanning/4](https://github.com/leonardocustodio/mkdocs-copy-to-llm/security/code-scanning/4)

To fix the problem, we should parse the `editUrl` using the standard `URL` constructor and check that its `hostname` is exactly `github.com` before performing the replacement. This ensures that only URLs with the correct host are rewritten, and not those that merely contain `github.com` somewhere in the string. The change should be made in the `getMdFileUrl` function, specifically replacing the substring check on line 111 with a proper host check. No new dependencies are needed, as the `URL` class is available in all modern browsers.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


___

### **PR Type**
Bug fix


___

### **Description**
- Parse edit URL with URL constructor

- Verify hostname equals "github.com"

- Wrap parsing in try/catch fallback

- Preserve non-GitHub fallback logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Find edit link"] --> B["Parse URL"]
  B -- "hostname == github.com" --> C["Rewrite raw URL"]
  B -- "error or mismatch" --> D["Fallback logic"]
  C --> E["Return raw URL"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>copy-to-llm.js</strong><dd><code>Secure edit URL parsing and rewriting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mkdocs_copy_to_llm/assets/js/copy-to-llm.js

<ul><li>Use URL constructor instead of substring check<br> <li> Add try/catch for URL parsing errors<br> <li> Check parsedUrl.hostname === "github.com"<br> <li> Retain fallback for non-GitHub URLs</ul>


</details>


  </td>
  <td><a href="https://github.com/leonardocustodio/mkdocs-copy-to-llm/pull/5/files#diff-73ccf5f117b7831ae070b0443da435b0b390e9b8dce4448ee971408461cdcabb">+10/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

