### PR TITLE
Potential fix for code scanning alert no. 11: Incomplete multi-character sanitization

### DIFF
--- a/docs/assets/copy-to-llm/copy-to-llm.js
+++ b/docs/assets/copy-to-llm/copy-to-llm.js
@@ -226,8 +226,14 @@ ${content}`;
       .replace(/<a[^>]*href="([^"]*)"[^>]*>(.*?)<\/a>/g, '[$2]($1)')
       .replace(/<li[^>]*>(.*?)<\/li>/g, '- $1\n')
       .replace(/<p[^>]*>(.*?)<\/p>/g, '$1\n\n')
-      .replace(/<br[^>]*>/g, '\n')
-      .replace(/<[^>]+>/g, '');
+      .replace(/<br[^>]*>/g, '\n');
+    
+    // Remove *all* HTML tags, even if left as fragments, by repeating until stable
+    let previousText;
+    do {
+      previousText = text;
+      text = text.replace(/<[^>]+>/g, '');
+    } while (text !== previousText);
 
     // Clean up extra whitespace
     return text.replace(/\n{3,}/g, '\n\n').trim();


### PR DESCRIPTION
### **User description**
Potential fix for [https://github.com/leonardocustodio/mkdocs-copy-to-llm/security/code-scanning/11](https://github.com/leonardocustodio/mkdocs-copy-to-llm/security/code-scanning/11)

The best fix is to ensure that multi-character "removal" is repeated until the potentially hazardous content is fully removed. This can be accomplished by repeatedly applying the tag-removal regex on the text until no further matches are found. This way, any fragments left behind after one pass will be removed on subsequent passes, preventing recursive or overlapping tags from escaping. 

Specifically:
- In function `cleanContentForLLM`, after constructing the `text` variable, add logic that repeats the `<[^>]+>` replacement (and any similar risky replacements) in a loop until the string no longer changes.
- Optionally, abstract this logic into a utility function for readability.
- All changes are within docs/assets/copy-to-llm/copy-to-llm.js, specifically the `cleanContentForLLM` function.
- Make no changes to imports, as this is standard JavaScript functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


___

### **PR Type**
Bug fix


___

### **Description**
- Repeat HTML tag removal until stable

- Prevent leftover fragment tags in output

- Preserve existing Markdown conversions

- Normalize whitespace after sanitization


___

### Diagram Walkthrough


```mermaid
flowchart LR
  input["HTML-rich content"]
  convert["Convert known tags to Markdown"]
  loop["Iteratively strip remaining <...> tags"]
  cleanup["Collapse extra newlines and trim"]
  output["Clean Markdown text"]
  input -- "process" --> convert
  convert -- "set text" --> loop
  loop -- "repeat until unchanged" --> loop
  loop -- "stable" --> cleanup
  cleanup --> output
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>copy-to-llm.js</strong><dd><code>Iterative HTML tag stripping for safer sanitization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/assets/copy-to-llm/copy-to-llm.js

<ul><li>Replace single-pass tag strip with loop<br> <li> Iteratively remove residual HTML fragments<br> <li> Keep existing HTML-to-Markdown replacements<br> <li> Maintain whitespace cleanup logic</ul>


</details>


  </td>
  <td><a href="https://github.com/leonardocustodio/mkdocs-copy-to-llm/pull/16/files#diff-e9491918b24ed41f445c2345b5e544b695484ee7375f42ed1260a38aaa81fd64">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

